### PR TITLE
separate order of grid items from alignment

### DIFF
--- a/csswizardry-grids.scss
+++ b/csswizardry-grids.scss
@@ -260,7 +260,7 @@ $class-type:            unquote(".");
 #{$class-type}grid--rev{
     @extend #{$class-type}grid;
     direction:rtl;
-    text-align:right;
+    text-align:left;
 
     > #{$class-type}grid__item{
         direction:ltr;
@@ -278,6 +278,19 @@ $class-type:            unquote(".");
 
     > #{$class-type}grid__item{
         padding-left:0;
+    }
+}
+
+
+/**
+ * Align the entire grid to the right
+ */
+#{$class-type}grid--right{
+    @extend #{$class-type}grid;
+    text-align:right;
+
+    > #{$class-type}grid__item{
+        text-align:left;
     }
 }
 


### PR DESCRIPTION
When the order of grid items is reversed, the desired behaviour is not
necessarily to align the entire grid to the right. It can be seen when
grid items widths don't add up to 1 (for example, they add up to three
quarters). Better to separate concepts of order and alignment.
- removed `text-align:right` from `grid--rev` and added
  `text-align:left`
- added `grid--right` modifier to manage right aligment of grid;
