### PR TITLE
Allow to namespace the compiled classnames

### DIFF
--- a/csswizardry-grids.scss
+++ b/csswizardry-grids.scss
@@ -88,6 +88,13 @@ $gutter:                24px!default;
 
 
 /**
+ * ‘.grid‘ classes already taken on a page? Use this setting to namespace the output
+ * classes. For example, set this to ‘foo-‘ to get ‘.foo-grid‘, ‘.foo-grid__item‘, etc.
+ */
+$namespace:    ""!default;
+
+
+/**
  * Would you like Sass’ silent classes, or regular CSS classes?
  */
 $use-silent-classes:    false!default;
@@ -147,7 +154,7 @@ $breakpoint-has-pull:   ('palm', 'lap', 'portable', 'desk')!default;
  * You do not need to edit anything from this line onward; csswizardry-grids is
  * good to go. Happy griddin’!
  */
-$class-type:            unquote(".");
+$class-type:            unquote(".") + $namespace;
 
 @if $use-silent-classes == true{
     $class-type:        unquote("%");


### PR DESCRIPTION
In some scenarios, classnames like `.grid` could already be taken in a given page.
If these are not under your control, a namespacing feature would be helpful.

This pull request adds a `$namespace` var(defaulting to `""`)  which allows to produce eg. `.foo-grid`, `.foo-grid__item`, etc.
