### PR TITLE
Added !global to $class-type

### DIFF
--- a/csswizardry-grids.scss
+++ b/csswizardry-grids.scss
@@ -150,7 +150,7 @@ $breakpoint-has-pull:   ('palm', 'lap', 'portable', 'desk')!default;
 $class-type:            unquote(".");
 
 @if $use-silent-classes == true{
-    $class-type:        unquote("%");
+    $class-type:        unquote("%")!global;
 }
 
 


### PR DESCRIPTION
Silent classes weren't working in newer versions of Sass (3.2+) because variable scope changed. The intended behavior was repaired by overtly specifying !global.
