### PR TITLE
Edit: letter-spacing hack, -0.31 -> -0.32

### DIFF
--- a/csswizardry-grids.scss
+++ b/csswizardry-grids.scss
@@ -212,7 +212,7 @@ $class-type: if($use-silent-classes, unquote("%"), unquote("."));
     padding:0;                      /* [2] */
     margin-left:-$gutter;           /* [3] */
     @if not $use-markup-fix {
-        letter-spacing:-0.31em;
+        letter-spacing:-0.32em;
     }
 }
 


### PR DESCRIPTION
I fixed this iv'd been looking around why the grid fails by 1px at last i found that the letter-spacing interpret by chrome needs to be -0.32em else the grid fails in Chrome latest build "Version 37.0.2062.103 m"
